### PR TITLE
Fix `main branch` link in step 6 of contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@ Below are steps you may follow as you write your contribution.
 3. In your Code Editor, Open the repository and Create a branch of what you plan to write to the repository. A good convention of your branch name is `your-name-feature-x`. 
 4. Create a `directory/folder` with your name. Your work will go into this `folder`. A good to use convention is `FirstName_LastName`
 5. Save your work and Push to your branch:rocket:
-6. Go to https://github.com/Musasizi/learn_html_css_js and create a Pull Request to the `[main branch](https://github.com/Musasizi/learn_html_css_js/tree/main)`
+6. Go to https://github.com/Musasizi/learn_html_css_js and create a Pull Request to the [main branch](https://github.com/Musasizi/learn_html_css_js/tree/main).
 7. Feel free to tag the project maintainer in your Pull Request's comments so as to avail it the attention it requires.
 8. Thats it! :sparkles: Congratulations on your contribution:rocket:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Below are steps you may follow as you write your contribution.
 3. In your Code Editor, Open the repository and Create a branch of what you plan to write to the repository. A good convention of your branch name is `your-name-feature-x`. 
 4. Create a `directory/folder` with your name. Your work will go into this `folder`. A good to use convention is `FirstName_LastName`
 5. Save your work and Push to your branch:rocket:
-6. Go to https://github.com/Musasizi/learn_html_css_js and create a Pull Request to the `[main branch](https://github.com/Musasizi/learn_html_css_js/tree/main)`
+6. Go to https://github.com/Musasizi/learn_html_css_js and create a Pull Request to the [main branch](https://github.com/Musasizi/learn_html_css_js/tree/main)
 7. Feel free to tag the project maintainer in your Pull Request's comments so as to avail it the attention it requires.
 8. Thats it! :sparkles: Congratulations on your contribution:rocket:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Below are steps you may follow as you write your contribution.
 3. In your Code Editor, Open the repository and Create a branch of what you plan to write to the repository. A good convention of your branch name is `your-name-feature-x`. 
 4. Create a `directory/folder` with your name. Your work will go into this `folder`. A good to use convention is `FirstName_LastName`
 5. Save your work and Push to your branch:rocket:
-6. Go to https://github.com/Musasizi/learn_html_css_js and create a Pull Request to the [main branch](https://github.com/Musasizi/learn_html_css_js/tree/main)
+6. Go to https://github.com/Musasizi/learn_html_css_js and create a Pull Request to the [main branch](https://github.com/Musasizi/learn_html_css_js/tree/main).
 7. Feel free to tag the project maintainer in your Pull Request's comments so as to avail it the attention it requires.
 8. Thats it! :sparkles: Congratulations on your contribution:rocket:


### PR DESCRIPTION
The `main branch` link in step 6 of contributing guide doesnt render properly. This pr seeks to rectify that.